### PR TITLE
Add progress window and download history

### DIFF
--- a/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader.csproj
+++ b/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Community.PowerToys.Run.Plugin.Dependencies" Version="0.91.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,5 +35,4 @@
 
   <ItemGroup>
     <Folder Include="bin\" />
-  </ItemGroup>
-</Project>
+  </ItemGroup></Project>

--- a/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/DownloadHistory.cs
+++ b/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/DownloadHistory.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Sqlite;
+
+namespace Community.PowerToys.Run.Plugin.VideoDownloader
+{
+    internal class DownloadHistory
+    {
+        private readonly string _dbPath;
+
+        public DownloadHistory(string dbPath)
+        {
+            _dbPath = dbPath;
+            EnsureDatabase();
+        }
+
+        private void EnsureDatabase()
+        {
+            using var connection = new SqliteConnection($"Data Source={_dbPath}");
+            connection.Open();
+            var command = connection.CreateCommand();
+            command.CommandText = @"CREATE TABLE IF NOT EXISTS History(
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Url TEXT,
+                FilePath TEXT,
+                Success INTEGER,
+                Timestamp TEXT,
+                Format TEXT
+            );";
+            command.ExecuteNonQuery();
+        }
+
+        public void Log(string url, string filePath, bool success, string format)
+        {
+            using var connection = new SqliteConnection($"Data Source={_dbPath}");
+            connection.Open();
+            var command = connection.CreateCommand();
+            command.CommandText = @"INSERT INTO History(Url, FilePath, Success, Timestamp, Format)
+                                    VALUES($u,$f,$s,$t,$fmt);";
+            command.Parameters.AddWithValue("$u", url);
+            command.Parameters.AddWithValue("$f", filePath);
+            command.Parameters.AddWithValue("$s", success ? 1 : 0);
+            command.Parameters.AddWithValue("$t", DateTime.UtcNow.ToString("o"));
+            command.Parameters.AddWithValue("$fmt", format);
+            command.ExecuteNonQuery();
+        }
+
+        public IEnumerable<(string Url, string FilePath, bool Success, string Timestamp, string Format)> GetLast(int count)
+        {
+            using var connection = new SqliteConnection($"Data Source={_dbPath}");
+            connection.Open();
+            var command = connection.CreateCommand();
+            command.CommandText = @"SELECT Url, FilePath, Success, Timestamp, Format FROM History ORDER BY Id DESC LIMIT $c;";
+            command.Parameters.AddWithValue("$c", count);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                yield return (
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetInt32(2) == 1,
+                    reader.GetString(3),
+                    reader.GetString(4)
+                );
+            }
+        }
+    }
+}

--- a/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/DownloadProgressWindow.cs
+++ b/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/DownloadProgressWindow.cs
@@ -1,0 +1,37 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Community.PowerToys.Run.Plugin.VideoDownloader
+{
+    internal class DownloadProgressWindow : Window
+    {
+        private readonly ProgressBar _bar;
+        private readonly TextBlock _label;
+
+        public DownloadProgressWindow()
+        {
+            Title = "Downloading...";
+            Width = 400;
+            Height = 120;
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            ResizeMode = ResizeMode.NoResize;
+
+            _bar = new ProgressBar { Minimum = 0, Maximum = 100, Height = 20, Margin = new Thickness(20,10,20,10) };
+            _label = new TextBlock { Margin = new Thickness(20,10,20,0) };
+
+            var panel = new StackPanel();
+            panel.Children.Add(_label);
+            panel.Children.Add(_bar);
+            Content = panel;
+        }
+
+        public void Update(double percent, string eta)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                _bar.Value = percent;
+                _label.Text = $"{percent:F1}% - ETA {eta}";
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SQLite history tracking
- show a progress window while downloading
- allow setting max concurrent downloads
- expose `--history` and `--settings` commands

## Testing
- `dotnet build VideoDownloader/VideoDownloader.sln -c Release`
- `dotnet test VideoDownloader/VideoDownloader.sln` *(fails: Could not find 'dotnet' host for the 'ARM64' architecture)*

