### PR TITLE
Add subtitle download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 > ⚠️ **Technical Note:** Muxed streams are deprecated by YouTube and are not guaranteed to be available for every video. If possible, avoid relying on them too much and instead perform muxing manually using the provided audio-only and video-only streams.
 
-> Note: Starting with v1.10, subtitle and metadata features were removed to improve speed and reliability for most users and videos. If you need subtitles, please use v1.0.9.
+> Note: Subtitle and metadata features are disabled by default for speed. Use the "Download Video with Subtitles" option when subtitles are needed.
 
 <div align="center">
 <p align="center">
@@ -428,8 +428,8 @@ MIT License. See [LICENSE](LICENSE).
 ## 📝 Changelog
 
 ### v1.10 (Latest)
-- Removed subtitles and metadata features to improve speed and reliability for most users and videos
-- If you need subtitles, you can use v1.0.9
+- Added option to download videos with subtitles on demand
+- Metadata features remain disabled to improve speed and reliability
 
 ### v1.0.8 ✅ PTRUN Compliant
 - **🔧 Fixed**: All PowerToys Run linting issues (PTRUN1301, PTRUN1303, PTRUN1401, PTRUN1402)

--- a/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/CHANGELOG.md
+++ b/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added option to download videos with subtitles on demand
+
 ## [1.0.9] - 2025-07-11
 ### 🚀 Performance & Stability
 - **Performance improvements:** Faster download speeds and reduced memory usage

--- a/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/Main.cs
+++ b/VideoDownloader/Community.PowerToys.Run.Plugin.VideoDownloader/Main.cs
@@ -90,6 +90,8 @@ namespace Community.PowerToys.Run.Plugin.VideoDownloader
                     results.Add(new Result { Title = $"🎵 Download Audio Only", SubTitle = $"Format: {_settings.AudioFormat.ToUpper()}. Safe filename handling enabled.", IcoPath = _iconPath, Action = _ => { DownloadAudio(search); return true; } });
                 }
 
+                results.Add(new Result { Title = $"💬 Download Video with Subtitles", SubTitle = $"Quality: {_settings.DefaultVideoQuality}. Safe filename handling with subtitles.", IcoPath = _iconPath, Action = _ => { DownloadVideoWithSubtitles(search); return true; } });
+
                 var qualityOptions = new[] { "1080p", "720p", "480p", "360p", "best" };
                 foreach (var quality in qualityOptions.Where(q => q != _settings.DefaultVideoQuality))
                 {
@@ -244,6 +246,8 @@ namespace Community.PowerToys.Run.Plugin.VideoDownloader
 
         private void DownloadVideo(string url) => DownloadWithQuality(url, _settings.DefaultVideoQuality);
 
+        private void DownloadVideoWithSubtitles(string url) => DownloadWithQuality(url, _settings.DefaultVideoQuality, true);
+
         private void DownloadAudio(string url)
         {
             Task.Run(() =>
@@ -300,7 +304,7 @@ namespace Community.PowerToys.Run.Plugin.VideoDownloader
             });
         }
 
-        private void DownloadWithQuality(string url, string quality)
+        private void DownloadWithQuality(string url, string quality, bool downloadSubtitles = false)
         {
             Task.Run(() =>
             {
@@ -330,6 +334,16 @@ namespace Community.PowerToys.Run.Plugin.VideoDownloader
                         "-o", $"\"{outputTemplate}\""
                     };
 
+                    if (downloadSubtitles)
+                    {
+                        commandParts.AddRange(new[]
+                        {
+                            "--write-subs",
+                            "--write-auto-subs",
+                            "--all-subs",
+                            "--convert-subs", "srt"
+                        });
+                    }
 
                     commandParts.Add($"\"{url}\"");
 


### PR DESCRIPTION
## Summary
- allow downloading videos with subtitles via yt-dlp
- document new subtitle support in README and changelog

## Testing
- `dotnet test VideoDownloader/VideoDownloader.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package dotnet-sdk-9.0)*
- `bash dotnet-install.sh --channel 9.0 --quality preview --install-dir /usr/share/dotnet9` *(fails: Failed to locate the latest version in channel '9.0' with 'preview' quality)*

------
https://chatgpt.com/codex/tasks/task_e_68bafbd5e7ec83228669442482a52574