### PR TITLE
ci: run build workflow on PRs

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches: [ master ]
 
 # Permissions for GITHUB_TOKEN (principle of least privilege)
 permissions:


### PR DESCRIPTION
Dependabot auto-merge job hangs forever in `Wait for all CI checks` because no CI workflow runs on PR branches (build-and-release is tag-only, snyk targets `main` but default branch is `master`).

Adds `pull_request: branches: [master]` trigger to build-and-release.yml. Release step stays gated by `startsWith(github.ref, "refs/tags/v")`, so PR builds never publish.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-videodownloader/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->