### PR TITLE
ci: point snyk workflow at master

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,9 +2,9 @@ name: snyk
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   security:


### PR DESCRIPTION
snyk.yml triggers on `main`, but the default branch is `master` — the workflow never runs. Switches both triggers to `master`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-videodownloader/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->