### PR TITLE
fix(ci): use PAT for release creation

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -295,4 +295,4 @@ jobs:
             release-artifacts/VideoDownloader-${{ steps.get_version.outputs.VERSION }}-ARM64.zip.sha256
             release-artifacts/checksums.txt
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
Releases created with `secrets.GITHUB_TOKEN` do not trigger `on: push: tags` workflows (GitHub prevents recursive workflow triggering). The auto-release flow bumps version → pushes tag, but the tag-triggered build never fires.

Switches the release step to `secrets.RELEASE_PAT` so future tags trigger the build+release pipeline. Secret already set in repo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-videodownloader/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->