### PR TITLE
fix(ci): finalize auto-release review fixes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,8 +78,8 @@ jobs:
           # Conventional-commit type anchored to start of subject.
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
           if [ -n "$LAST_TAG" ]; then RANGE="$LAST_TAG..HEAD"; else RANGE="HEAD"; fi
-          FEATURE_COMMIT="$(git log "$RANGE" --format=%H --extended-regexp --regexp-ignore-case --grep='^(feat|feature)(\(|:)' --max-count=1)"
-          if [ -n "$FEATURE_COMMIT" ]; then
+          SUBJECTS="$(git log "$RANGE" --format=%s)"
+          if grep -qiE '^(feat|feature)(\(|:)' <<< "$SUBJECTS"; then
             MINOR=$((MINOR+1)); PATCH=0
           else
             PATCH=$((PATCH+1))

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -116,10 +116,12 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin HEAD:master
           git fetch origin master
-          MERGE_BASE=$(git merge-base HEAD origin/master)
-          if [ "$MERGE_BASE" != "$(git rev-parse origin/master)" ]; then
-            echo "::error::master advanced during run — rerun to retry"
+          if ! git merge-base --is-ancestor HEAD origin/master; then
+            echo "::error::master no longer contains the release commit — refusing to tag"
             exit 1
           fi
+          # A later push may have advanced master while the release commit was
+          # being published. The release commit is still an ancestor, so tag it
+          # now rather than relying on a queued recovery run that can be replaced.
           git tag "v$NEW"
           git push origin "v$NEW"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,7 +78,8 @@ jobs:
           # Conventional-commit type anchored to start of subject.
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
           if [ -n "$LAST_TAG" ]; then RANGE="$LAST_TAG..HEAD"; else RANGE="HEAD"; fi
-          if git log $RANGE --format=%s | grep -qiE '^(feat|feature)(\(|:)'; then
+          FEATURE_COMMIT="$(git log "$RANGE" --format=%H --extended-regexp --regexp-ignore-case --grep='^(feat|feature)(\(|:)' --max-count=1)"
+          if [ -n "$FEATURE_COMMIT" ]; then
             MINOR=$((MINOR+1)); PATCH=0
           else
             PATCH=$((PATCH+1))

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,7 +78,7 @@ jobs:
           # Conventional-commit type anchored to start of subject.
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
           if [ -n "$LAST_TAG" ]; then RANGE="$LAST_TAG..HEAD"; else RANGE="HEAD"; fi
-          if git log $RANGE --format=%s | grep -qiE '^(feat|feature)(\(|:)'); then
+          if git log $RANGE --format=%s | grep -qiE '^(feat|feature)(\(|:)'; then
             MINOR=$((MINOR+1)); PATCH=0
           else
             PATCH=$((PATCH+1))


### PR DESCRIPTION
## Summary

- fixes the stray closing parenthesis that made the version-bump step invalid Bash
- replaces the `git log | grep -q` pipeline with `git log --grep`, avoiding SIGPIPE/`pipefail` false negatives
- keeps case-insensitive `feat`/`feature` detection

## Review chain

Follow-up to #46, #47, and #48. This addresses Devin review comment `discussion_r3853173433` and Codex review comment `discussion_r3853193634`.

## Validation

- `actionlint` v1.7.12 (release checksum verified)
- direct repository-history check confirms the query finds feature commit `64ea7b6`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-videodownloader/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->