### PR TITLE
fix(ci): quote feat-detection regex in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,7 +78,7 @@ jobs:
           # Conventional-commit type anchored to start of subject.
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
           if [ -n "$LAST_TAG" ]; then RANGE="$LAST_TAG..HEAD"; else RANGE="HEAD"; fi
-          if git log $RANGE --format=%s | grep -qiE '^(feat|feature)(\(|:)'); then
+          if git log $RANGE --format=%s | grep -qiE "^(feat|feature)(\(|:)" ; then
             MINOR=$((MINOR+1)); PATCH=0
           else
             PATCH=$((PATCH+1))


### PR DESCRIPTION
The single-quoted ERE `'^(feat|feature)(\\(|:)');` makes bash parse the trailing `)` as shell syntax → Auto Release fails on master. Double quotes keep the parens inside the pattern for grep while hiding them from bash. Verified locally: `feat:` → minor, `fix:` → patch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-videodownloader/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->