### PR TITLE
fix(ci): avoid SIGPIPE masking feature commits in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,7 +78,7 @@ jobs:
           # Conventional-commit type anchored to start of subject.
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
           if [ -n "$LAST_TAG" ]; then RANGE="$LAST_TAG..HEAD"; else RANGE="HEAD"; fi
-          if git log $RANGE --format=%s | grep -qiE "^(feat|feature)(\(|:)" ; then
+          if git log $RANGE --format=%s | grep -iE "^(feat|feature)(\(|:)" >/dev/null ; then
             MINOR=$((MINOR+1)); PATCH=0
           else
             PATCH=$((PATCH+1))


### PR DESCRIPTION
Addresses Codex P2 from #48: `grep -q` exits after the first match, sending SIGPIPE to `git log` (exit 141). With large ranges the pipeline can then evaluate false, silently producing a patch bump instead of minor.

Fix: drop `-q`, redirect full output to `/dev/null` — grep reads all input, no early exit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-videodownloader/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->